### PR TITLE
Updated city download to use city boundary box

### DIFF
--- a/meshtastic_tiles.py
+++ b/meshtastic_tiles.py
@@ -53,6 +53,10 @@ class CityLookup:
                 'name': result.get('display_name', 'Unknown'),
                 'lat': float(result['lat']),
                 'lon': float(result['lon']),
+                'south': float(result['boundingbox'][0]),
+                'north': float(result['boundingbox'][1]),
+                'west': float(result['boundingbox'][2]),
+                'east': float(result['boundingbox'][3]),
                 'type': result.get('type', 'unknown')
             }
             
@@ -85,16 +89,18 @@ class CityLookup:
             return None
         
         # Calculate bounding box
-        lats = [c['lat'] for c in all_coords]
-        lons = [c['lon'] for c in all_coords]
+        norths = [c['north'] for c in all_coords]
+        souths = [c['south'] for c in all_coords]
+        easts = [c['east'] for c in all_coords]
+        wests = [c['west'] for c in all_coords]
         
         # Convert km buffer to degrees (approximate)
         buffer_deg = buffer_km / 111.0  # ~111km per degree
         
-        north = max(lats) + buffer_deg
-        south = min(lats) - buffer_deg
-        east = max(lons) + buffer_deg
-        west = min(lons) - buffer_deg
+        north = max(norths) + buffer_deg
+        south = min(souths) - buffer_deg
+        east = max(easts) + buffer_deg
+        west = min(wests) - buffer_deg
         
         print(f"\n📦 Bounding box for {len(all_coords)} cities (±{buffer_km}km buffer):")
         print(f"   North: {north:.4f}")
@@ -416,10 +422,10 @@ def main():
         
         # Create bounding box around city
         buffer_deg = args.buffer / 111.0  # Convert km to degrees
-        north = coord['lat'] + buffer_deg
-        south = coord['lat'] - buffer_deg
-        east = coord['lon'] + buffer_deg
-        west = coord['lon'] - buffer_deg
+        north = coord['north'] + buffer_deg
+        south = coord['south'] - buffer_deg
+        east = coord['east'] + buffer_deg
+        west = coord['west'] - buffer_deg
         area_name = args.city
         
     elif args.cities:


### PR DESCRIPTION
### **User description**
Instead of using central cords of city +/- buffer get the boundary box of the city +/- buffer


___

### **PR Type**
Enhancement


___

### **Description**
- Replace city center coordinates with actual boundary boxes

- Use bounding box coordinates from geocoding API response

- Apply buffer to boundary extents instead of center point

- Improve geographic accuracy for city-based tile downloads


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["City Geocoding"] --> B["Extract Bounding Box"]
  B --> C["Apply Buffer to Bounds"]
  C --> D["Calculate Final Area"]
  E["Old: Center + Buffer"] -.-> F["New: Boundary + Buffer"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>meshtastic_tiles.py</strong><dd><code>Replace center coordinates with boundary boxes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

meshtastic_tiles.py

<ul><li>Extract bounding box coordinates from geocoding API response<br> <li> Replace center-based calculations with boundary-based calculations<br> <li> Update coordinate handling in both single and multiple city workflows<br> <li> Apply buffer to actual city boundaries instead of center points</ul>


</details>


  </td>
  <td><a href="https://github.com/JustDr00py/tdeck-maps/pull/4/files#diff-ad0212abda06c7711cb946cb469531c246a39763b1d74ae2863a9696f644d05c">+16/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

