### PR TITLE
Add preset regions, and map paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ python meshtastic_tiles.py --region usa --min-zoom 4 --max-zoom 8
 python meshtastic_tiles.py --region north_america --min-zoom 4 --max-zoom 8
 ```
 
-**Available regions:** `north_america`, `usa`, `canada`, `mexico`, `california`, `texas`, `alaska`, `florida`
+**Available regions:** `north_america`, `usa`, `canada`, `mexico`, `california`, `texas`, `alaska`, `florida`, `georgia`, `deep_southeast_usa`
 
 ### Method 4: Custom Coordinates
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ python meshtastic_tiles.py --region usa --min-zoom 4 --max-zoom 8
 python meshtastic_tiles.py --region north_america --min-zoom 4 --max-zoom 8
 ```
 
-**Available regions:** `north_america`, `usa`, `canada`, `mexico`, `california`, `texas`, `alaska`
+**Available regions:** `north_america`, `usa`, `canada`, `mexico`, `california`, `texas`, `alaska`, `florida`
 
 ### Method 4: Custom Coordinates
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ python meshtastic_tiles.py --city "Denver" --source terrain
 
 # Cycling-focused
 python meshtastic_tiles.py --city "Denver" --source cycle
+
+# Google Earth Hybrid
+python meshtastic_tiles.py --city "Denver" --source Google_Terrain_Hybrid
+
+# CartoDb Dark Matter
+python meshtastic_tiles.py --city "Denver" --source CartoDb_Dark_Matter
 ```
 
 ## 🔍 Zoom Levels Guide

--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ python meshtastic_tiles.py --city "Denver" --source Google_Terrain_Hybrid
 
 # CartoDb Dark Matter
 python meshtastic_tiles.py --city "Denver" --source CartoDb_Dark_Matter
+
+# Custom Title Server (Point to a custom URL in script)
+python meshtastic_tiles.py --city "Denver" --source custom_tile_server
 ```
 
 ## 🔍 Zoom Levels Guide

--- a/maps.html
+++ b/maps.html
@@ -226,6 +226,9 @@
                     <option value="osm">OpenStreetMap</option>
                     <option value="satellite">Satellite</option>
                     <option value="terrain">Terrain</option>
+					<option value="cycle">Cycle</option>
+					<option value="Google_Sat_Hybrid">GoogleSatHybrid</option>
+					<option value="CartoDb_Dark_Matter">CartoDarkMatter</option>
                 </select>
             </div>
             <div class="selection-info hidden" id="selectionInfo">
@@ -286,6 +289,8 @@
                     <option value="satellite">Satellite</option>
                     <option value="terrain">Terrain</option>
                     <option value="cycle">Cycle</option>
+					<option value="Google_Sat_Hybrid">GoogleSatHybrid</option>
+					<option value="CartoDb_Dark_Matter">CartoDarkMatter</option>
                 </select>
             </div>
             
@@ -351,6 +356,9 @@ Select an area on the map to generate command...
             osm: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
             satellite: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
             terrain: 'https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png'
+			cycle: f"https://tile.thunderforest.com/cycle/{zoom}/{x}/{y}.png",
+            Google_Sat_Hybrid: f"https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={zoom}",
+            CartoDb_Dark_Matter: f"http://basemaps.cartocdn.com/dark_all/{zoom}/{x}/{y}.png",
         };
         
         // Initialize map

--- a/meshtastic_tiles.py
+++ b/meshtastic_tiles.py
@@ -344,7 +344,13 @@ def get_region_bounds(region):
             'south': 54.4,   # Aleutian Islands
             'east': -129.9,  # Canadian border
             'west': -172.4   # Aleutian Islands
-        }
+        },
+        'florida': {
+            'north': 31.44,  # Alabama
+            'south': 24.1,   # Gulf of Mexico
+            'east': -79.11,  # Alantic Ocean
+            'west': -88.38,  # Gulf of Mexico
+        },
     }
     return regions.get(region.lower())
 
@@ -354,7 +360,7 @@ def main():
     # Method selection (mutually exclusive)
     method_group = parser.add_mutually_exclusive_group(required=True)
     method_group.add_argument('--region', type=str, 
-                        choices=['north_america', 'usa', 'canada', 'mexico', 'california', 'texas', 'alaska'],
+                        choices=['north_america', 'usa', 'canada', 'mexico', 'california', 'texas', 'alaska', 'florida'],
                         help='Predefined region')
     method_group.add_argument('--city', type=str, help='City name (e.g., "San Francisco" or "Portland, Oregon")')
     method_group.add_argument('--cities', type=str, help='Multiple cities separated by semicolons (e.g., "San Francisco; Oakland; San Jose")')

--- a/meshtastic_tiles.py
+++ b/meshtastic_tiles.py
@@ -147,7 +147,7 @@ class MeshtasticTileGenerator:
             "terrain": f"https://tile.opentopomap.org/{zoom}/{x}/{y}.png",
             "cycle": f"https://tile.thunderforest.com/cycle/{zoom}/{x}/{y}.png",
             "Google_Satellite_Hybrid": f"https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={z}",
-            "CartoDb Dark Matter": f"http://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png"
+            "CartoDb_Dark_Matter": f"http://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png"
         }
         return sources.get(source, sources["osm"])
     

--- a/meshtastic_tiles.py
+++ b/meshtastic_tiles.py
@@ -145,7 +145,9 @@ class MeshtasticTileGenerator:
             "osm": f"https://tile.openstreetmap.org/{zoom}/{x}/{y}.png",
             "satellite": f"https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{zoom}/{y}/{x}",
             "terrain": f"https://tile.opentopomap.org/{zoom}/{x}/{y}.png",
-            "cycle": f"https://tile.thunderforest.com/cycle/{zoom}/{x}/{y}.png"
+            "cycle": f"https://tile.thunderforest.com/cycle/{zoom}/{x}/{y}.png",
+            "Google_Satellite_Hybrid": f"https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={z}",
+            "CartoDb Dark Matter": f"http://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png"
         }
         return sources.get(source, sources["osm"])
     

--- a/meshtastic_tiles.py
+++ b/meshtastic_tiles.py
@@ -147,7 +147,8 @@ class MeshtasticTileGenerator:
             "terrain": f"https://tile.opentopomap.org/{zoom}/{x}/{y}.png",
             "cycle": f"https://tile.thunderforest.com/cycle/{zoom}/{x}/{y}.png",
             "Google_Sat_Hybrid": f"https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={zoom}",
-            "CartoDb_Dark_Matter": f"http://basemaps.cartocdn.com/dark_all/{zoom}/{x}/{y}.png"
+            "CartoDb_Dark_Matter": f"http://basemaps.cartocdn.com/dark_all/{zoom}/{x}/{y}.png",
+            #"custom_tile_server": f __fill in custom url path here__/{zoom}/{x}/{y}.png"       #This path will require a custom tile server, preferably a local server.
         }
         return sources.get(source, sources["osm"])
     

--- a/meshtastic_tiles.py
+++ b/meshtastic_tiles.py
@@ -348,10 +348,22 @@ def get_region_bounds(region):
             'west': -172.4   # Aleutian Islands
         },
         'florida': {
-            'north': 31.44,  # Alabama
-            'south': 24.1,   # Gulf of Mexico
+            'north': 31.44,  # Alabama/Georgia
+            'south': 24.1,   # Strait of Florida
             'east': -79.11,  # Alantic Ocean
             'west': -88.38,  # Gulf of Mexico
+        },
+        'georgia': {
+            'north': 35.2,   # Tennesse/North Carolina
+            'south': 30.36,  # Florida
+            'east': -80.75,  # Alantic Ocean
+            'west': -85.79,  # Alabama
+        },
+        'deep_southeast_usa': {
+            'north': 35.2,   # Washington to Saint Louisiana
+            'south': 30.36,  # Strait of Florida
+            'east': -80.75,  # Alantic Ocean
+            'west': -85.79,  # Mississippi
         },
     }
     return regions.get(region.lower())

--- a/meshtastic_tiles.py
+++ b/meshtastic_tiles.py
@@ -146,8 +146,8 @@ class MeshtasticTileGenerator:
             "satellite": f"https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{zoom}/{y}/{x}",
             "terrain": f"https://tile.opentopomap.org/{zoom}/{x}/{y}.png",
             "cycle": f"https://tile.thunderforest.com/cycle/{zoom}/{x}/{y}.png",
-            "Google_Satellite_Hybrid": f"https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={z}",
-            "CartoDb_Dark_Matter": f"http://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png"
+            "Google_Sat_Hybrid": f"https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={zoom}",
+            "CartoDb_Dark_Matter": f"http://basemaps.cartocdn.com/dark_all/{zoom}/{x}/{y}.png"
         }
         return sources.get(source, sources["osm"])
     

--- a/meshtastic_tiles.py
+++ b/meshtastic_tiles.py
@@ -393,7 +393,7 @@ def main():
     # Tile generation options
     parser.add_argument('--min-zoom', type=int, default=8, help='Minimum zoom level')
     parser.add_argument('--max-zoom', type=int, default=12, help='Maximum zoom level')
-    parser.add_argument('--source', default='osm', choices=['osm', 'satellite', 'terrain', 'cycle'],
+    parser.add_argument('--source', default='osm', choices=['osm', 'satellite', 'terrain', 'cycle', 'Google_Terrain_Hybrid', 'CartoDb_Dark_Matter'],
                         help='Map source')
     parser.add_argument('--output-dir', default='tiles', help='Output directory')
     parser.add_argument('--delay', type=float, default=0.2, help='Delay between requests (seconds)')


### PR DESCRIPTION
### **User description**
This push adds in custom presets for FL, GA and the Deep southeast of the USA. It also adds in a slot for custom tile server paths, as well as several other publicly available tile servers.


___

### **PR Type**
Enhancement


___

### **Description**
- Add three new tile server sources: Cycle, Google Satellite Hybrid, CartoDB Dark Matter

- Introduce three new preset regions: Florida, Georgia, Deep Southeast USA

- Add custom tile server path support for local server configurations

- Update UI and documentation with new map sources and region options


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Tile Server Sources"] -->|"Add"| B["Cycle, Google Sat, CartoDB"]
  C["Region Presets"] -->|"Add"| D["Florida, Georgia, Deep Southeast"]
  E["Custom Tile Server"] -->|"Support"| F["Local Server Path"]
  B -->|"Update"| G["maps.html & meshtastic_tiles.py"]
  D -->|"Update"| G
  F -->|"Update"| G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>maps.html</strong><dd><code>Add new tile server options to map UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

maps.html

<ul><li>Add three new tile layer options to map style selector: Cycle, <br>GoogleSatHybrid, CartoDarkMatter<br> <li> Add corresponding tile layer URLs in JavaScript tileLayers object with <br>proper coordinate formatting<br> <li> Update both map style dropdown and tile source selection dropdown with <br>new options</ul>


</details>


  </td>
  <td><a href="https://github.com/JustDr00py/tdeck-maps/pull/7/files#diff-b23639c3284c8c00e897b09d74b52aeab948b1c408d6bfc90fe56e6afdf6ab39">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>meshtastic_tiles.py</strong><dd><code>Add tile sources and region presets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

meshtastic_tiles.py

<ul><li>Add Google Satellite Hybrid and CartoDB Dark Matter tile sources to <br>sources dictionary<br> <li> Include commented custom tile server template for user configuration<br> <li> Add three new region presets: florida, georgia, deep_southeast_usa <br>with bounding box coordinates<br> <li> Update region choices in argument parser to include new regions</ul>


</details>


  </td>
  <td><a href="https://github.com/JustDr00py/tdeck-maps/pull/7/files#diff-ad0212abda06c7711cb946cb469531c246a39763b1d74ae2863a9696f644d05c">+24/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document new regions and tile sources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Update available regions list to include florida, georgia, <br>deep_southeast_usa<br> <li> Add usage examples for Google Earth Hybrid and CartoDB Dark Matter <br>sources<br> <li> Add example for custom tile server configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/JustDr00py/tdeck-maps/pull/7/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

