### PR TITLE
Update README with specific tiles folder path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install pillow requests
 python meshtastic_tiles.py --city "San Francisco" --min-zoom 8 --max-zoom 12
 ```
 
-3. **Copy the `tiles` folder to your T-Deck's SD card**
+3. **Copy the `tiles` folder to your T-Deck's SD card under `maps` directory **
 
 4. **Configure Meshtastic to use offline tiles**
 


### PR DESCRIPTION
### **User description**
Clarified instructions for copying tiles folder.


___

### **PR Type**
Documentation


___

### **Description**
- Clarified tiles folder destination path in setup instructions

- Specified that tiles should be copied under `maps` directory


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["README Instructions"] -- "Updated destination" --> B["Copy tiles to maps directory"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Clarify tiles folder destination path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updated step 3 instructions to specify tiles folder should be copied <br>under <code>maps</code> directory on T-Deck's SD card<br> <li> Improved clarity of setup instructions for users</ul>


</details>


  </td>
  <td><a href="https://github.com/JustDr00py/tdeck-maps/pull/8/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

