### PR TITLE
Add Southeast Asia regions (Malaysia, Singapore)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,15 @@ python meshtastic_tiles.py --region texas --min-zoom 6 --max-zoom 10
 # Countries/continents
 python meshtastic_tiles.py --region usa --min-zoom 4 --max-zoom 8
 python meshtastic_tiles.py --region north_america --min-zoom 4 --max-zoom 8
+
+# Southeast Asia
+python meshtastic_tiles.py --region malaysia --min-zoom 6 --max-zoom 10
+python meshtastic_tiles.py --region malaysia_peninsular --min-zoom 7 --max-zoom 11
+python meshtastic_tiles.py --region malaysia_east --min-zoom 7 --max-zoom 11
+python meshtastic_tiles.py --region singapore --min-zoom 10 --max-zoom 14
 ```
 
-**Available regions:** `north_america`, `usa`, `canada`, `mexico`, `california`, `texas`, `alaska`
+**Available regions:** `north_america`, `usa`, `canada`, `mexico`, `california`, `texas`, `alaska`, `malaysia`, `malaysia_peninsular`, `malaysia_east`, `singapore`
 
 ### Method 4: Custom Coordinates
 

--- a/meshtastic_tiles.py
+++ b/meshtastic_tiles.py
@@ -344,6 +344,30 @@ def get_region_bounds(region):
             'south': 54.4,   # Aleutian Islands
             'east': -129.9,  # Canadian border
             'west': -172.4   # Aleutian Islands
+        },
+        'malaysia': {
+            'north': 7.4,     # North of Banggi Island, Sabah (7.25°N)
+            'south': 0.8,     # South of Sarawak border
+            'east': 119.4,    # East of Tawau, Sabah
+            'west': 99.5      # West of Perak Island, Kedah (99.63°E)
+        },
+        'malaysia_peninsular': {
+            'north': 7.05,    # North of Perlis (northernmost ~6.95°N)
+            'south': 1.1,     # South of Tanjung Piai, Johor (1.268°N)
+            'east': 104.6,    # East coast buffer
+            'west': 99.5      # West of Perak Island, Kedah (99.63°E)
+        },
+        'malaysia_east': {
+            'north': 7.4,     # North of Banggi Island, Sabah (7.25°N)
+            'south': 0.8,     # South of Sarawak border
+            'east': 119.4,    # East of Tawau, Sabah
+            'west': 109.4     # West of Sematan, Sarawak (~109°E)
+        },
+        'singapore': {
+            'north': 1.55,    # North of Sembawang (1.4706°N)
+            'south': 1.1,     # South of Pulau Satumu (1.1594°N)
+            'east': 104.5,    # East of Pedra Branca (104.4075°E)
+            'west': 103.55    # West of Tuas (~103.60°E)
         }
     }
     return regions.get(region.lower())
@@ -354,7 +378,7 @@ def main():
     # Method selection (mutually exclusive)
     method_group = parser.add_mutually_exclusive_group(required=True)
     method_group.add_argument('--region', type=str, 
-                        choices=['north_america', 'usa', 'canada', 'mexico', 'california', 'texas', 'alaska'],
+                        choices=['north_america', 'usa', 'canada', 'mexico', 'california', 'texas', 'alaska', 'malaysia', 'malaysia_peninsular', 'malaysia_east', 'singapore'],
                         help='Predefined region')
     method_group.add_argument('--city', type=str, help='City name (e.g., "San Francisco" or "Portland, Oregon")')
     method_group.add_argument('--cities', type=str, help='Multiple cities separated by semicolons (e.g., "San Francisco; Oakland; San Jose")')


### PR DESCRIPTION
## Summary
- Add predefined bounding boxes for `malaysia`, `malaysia_peninsular`, `malaysia_east`, and `singapore`
- Coordinates verified against geographic extremes (e.g. Pedra Branca at 104.41°E for Singapore east, Banggi Island at 7.25°N for Sabah north, Perlis at 6.95°N for peninsular north)
- Bounds are buffered outward to ensure no territory is cropped
- Update README with Southeast Asia usage examples and updated available regions list

## Test plan
- [x] Run `--region malaysia` and verify full country coverage including Sabah/Sarawak
- [x] Run `--region malaysia_peninsular` and verify coverage includes northern Perlis and southern Johor
- [x] Run `--region malaysia_east` and verify Sabah and Sarawak are fully covered
- [x] Run `--region singapore` and verify Pedra Branca (104.41°E) is included in downloaded tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)