### PR TITLE
fix: route tile downloads through MapTiler to stop OSM 403 blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+tiles
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -9,19 +9,27 @@ Generate offline map tiles for your Meshtastic T-Deck device! This tool download
 pip install pillow requests
 ```
 
-2. **Get a free MapTiler API key** at https://maptiler.com/ and export it:
+2. **Get a free MapTiler API key** at https://maptiler.com/ and export the required environment variables:
 ```bash
 export MAPTILER_KEY=your_key_here
+# Required — sent in the HTTP User-Agent so tile providers can contact you
+export TDECK_MAPS_CONTACT="you@example.com"
+# Required — sent as HTTP Referer (any URL or project identifier works)
+export TDECK_MAPS_REFERER="https://github.com/you/tdeck-maps"
 ```
+
+Both `TDECK_MAPS_CONTACT` and `TDECK_MAPS_REFERER` must be set — every tile
+provider policy (MapTiler, OSM, Nominatim) requires an identifiable User-Agent
+with a way to reach you. `--contact` on the CLI overrides `TDECK_MAPS_CONTACT`.
 
 3. **Generate tiles for your city:**
 ```bash
 python meshtastic_tiles.py --city "San Francisco" --min-zoom 8 --max-zoom 12
 ```
 
-3. **Copy the `tiles` folder to your T-Deck's SD card**
+4. **Copy the `tiles` folder to your T-Deck's SD card**
 
-4. **Configure Meshtastic to use offline tiles**
+5. **Configure Meshtastic to use offline tiles**
 
 ## 📋 Features
 
@@ -154,8 +162,9 @@ python meshtastic_tiles.py --city "Denver" --source osm-direct --i-understand-os
 
 The OSM tile policy forbids bulk downloading from `tile.openstreetmap.org`. Previous versions of this
 script violated that policy and eventually got `403 Access Blocked`. Using MapTiler (or any other tile
-provider that permits offline caching) is the correct fix. The User-Agent header now also carries a
-contact address (`--contact`, defaults to the maintainer's email) as every major provider requires.
+provider that permits offline caching) is the correct fix. Every request also carries an identifying
+`User-Agent` (contact email from `TDECK_MAPS_CONTACT` or `--contact`) and `Referer` (from
+`TDECK_MAPS_REFERER`), as every major provider requires.
 
 ## 🔍 Zoom Levels Guide
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ Generate offline map tiles for your Meshtastic T-Deck device! This tool download
 pip install pillow requests
 ```
 
-2. **Generate tiles for your city:**
+2. **Get a free MapTiler API key** at https://maptiler.com/ and export it:
+```bash
+export MAPTILER_KEY=your_key_here
+```
+
+3. **Generate tiles for your city:**
 ```bash
 python meshtastic_tiles.py --city "San Francisco" --min-zoom 8 --max-zoom 12
 ```
@@ -122,10 +127,17 @@ python meshtastic_tiles.py --coords --north 40.8 --south 40.6 --east -74.0 --wes
 
 ## 🗺️ Map Sources
 
-Choose different map types with the `--source` option:
+All default sources go through **MapTiler** (free tier, requires an API key). OSM's own tile servers
+explicitly prohibit bulk downloads — see [OSM Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/) —
+so this tool no longer uses them by default. `osm-direct` is available as an opt-in and will likely get you
+`403 Blocked`.
+
+Pass the key via `--maptiler-key` or the `MAPTILER_KEY` env var.
 
 ```bash
-# Standard street map (default)
+export MAPTILER_KEY=your_key_here
+
+# Standard street map (default, via MapTiler)
 python meshtastic_tiles.py --city "Denver" --source osm
 
 # Satellite imagery
@@ -134,9 +146,16 @@ python meshtastic_tiles.py --city "Denver" --source satellite
 # Topographic/terrain
 python meshtastic_tiles.py --city "Denver" --source terrain
 
-# Cycling-focused
-python meshtastic_tiles.py --city "Denver" --source cycle
+# Raw OSM servers (policy-restricted — expect blocks):
+python meshtastic_tiles.py --city "Denver" --source osm-direct --i-understand-osm-policy
 ```
+
+### Why we require an API key now
+
+The OSM tile policy forbids bulk downloading from `tile.openstreetmap.org`. Previous versions of this
+script violated that policy and eventually got `403 Access Blocked`. Using MapTiler (or any other tile
+provider that permits offline caching) is the correct fix. The User-Agent header now also carries a
+contact address (`--contact`, defaults to the maintainer's email) as every major provider requires.
 
 ## 🔍 Zoom Levels Guide
 

--- a/maps.html
+++ b/maps.html
@@ -223,10 +223,12 @@
             <div id="map"></div>
             <div class="map-controls">
                 <select id="mapStyle">
-                    <option value="osm">OpenStreetMap</option>
+                    <option value="osm">OpenStreetMap (MapTiler)</option>
                     <option value="satellite">Satellite</option>
                     <option value="terrain">Terrain</option>
                 </select>
+                <input type="text" id="previewKey" placeholder="MapTiler key (for preview)" style="margin-top:4px;width:100%;">
+                <small style="color:#ccc;">Preview needs a MapTiler key. Get one at maptiler.com.</small>
             </div>
             <div class="selection-info hidden" id="selectionInfo">
                 <div>Click and drag to select area</div>
@@ -282,22 +284,30 @@
             <div class="control-group">
                 <h3>🗺️ Map Source</h3>
                 <select id="tileSource">
-                    <option value="osm">OpenStreetMap</option>
-                    <option value="satellite">Satellite</option>
-                    <option value="terrain">Terrain</option>
-                    <option value="cycle">Cycle</option>
+                    <option value="osm">OpenStreetMap (via MapTiler)</option>
+                    <option value="satellite">Satellite (via MapTiler)</option>
+                    <option value="terrain">Terrain (via MapTiler)</option>
+                    <option value="osm-direct">OSM direct — policy-restricted</option>
                 </select>
+                <div class="form-row" style="margin-top:0.5rem;">
+                    <label>MapTiler key:</label>
+                    <input type="text" id="maptilerKey" placeholder="required for MapTiler sources">
+                </div>
+                <div class="form-row">
+                    <label>Contact:</label>
+                    <input type="text" id="contact" value="ekarwatowski@gmail.com" placeholder="email or URL for User-Agent">
+                </div>
             </div>
             
             <div class="control-group">
                 <h3>⚙️ Advanced Options</h3>
                 <div class="form-row">
                     <label>Delay:</label>
-                    <input type="number" id="delay" value="0.2" step="0.1" min="0.1">
+                    <input type="number" id="delay" value="0.5" step="0.1" min="0.1">
                 </div>
                 <div class="form-row">
                     <label>Workers:</label>
-                    <input type="number" id="workers" value="3" min="1" max="10">
+                    <input type="number" id="workers" value="2" min="1" max="10">
                 </div>
                 <div class="form-row">
                     <label>Output:</label>
@@ -346,20 +356,24 @@ Select an area on the map to generate command...
         let startPoint = null;
         let currentTileLayer = null;
         
-        // Map tile layers
-        const tileLayers = {
-            osm: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-            satellite: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
-            terrain: 'https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png'
-        };
-        
+        // Map tile layers (preview-only; requires MapTiler key)
+        function tileUrl(style) {
+            const key = document.getElementById('previewKey')?.value || '';
+            const layers = {
+                osm:       `https://api.maptiler.com/maps/openstreetmap/{z}/{x}/{y}.png?key=${key}`,
+                satellite: `https://api.maptiler.com/tiles/satellite-v2/{z}/{x}/{y}.jpg?key=${key}`,
+                terrain:   `https://api.maptiler.com/maps/topo-v2/{z}/{x}/{y}.png?key=${key}`,
+            };
+            return layers[style] || layers.osm;
+        }
+
         // Initialize map
         function initMap() {
             map = L.map('map').setView([39.7392, -104.9903], 8); // Denver
-            
+
             // Add default tile layer
-            currentTileLayer = L.tileLayer(tileLayers.osm, {
-                attribution: '© OpenStreetMap contributors'
+            currentTileLayer = L.tileLayer(tileUrl('osm'), {
+                attribution: '© OpenStreetMap contributors · © MapTiler'
             }).addTo(map);
             
             // Add selection functionality
@@ -442,8 +456,8 @@ Select an area on the map to generate command...
                 map.removeLayer(currentTileLayer);
             }
             
-            currentTileLayer = L.tileLayer(tileLayers[style], {
-                attribution: style === 'osm' ? '© OpenStreetMap contributors' : '© Map tiles'
+            currentTileLayer = L.tileLayer(tileUrl(style), {
+                attribution: '© OpenStreetMap contributors · © MapTiler'
             }).addTo(map);
         }
         
@@ -507,13 +521,29 @@ Select an area on the map to generate command...
             const delay = document.getElementById('delay').value;
             const workers = document.getElementById('workers').value;
             const outputDir = document.getElementById('outputDir').value;
-            
+            const maptilerKey = document.getElementById('maptilerKey').value.trim();
+            const contact = document.getElementById('contact').value.trim();
+
             if (!north || !south || !east || !west) {
                 document.getElementById('commandOutput').textContent = 'Select an area on the map first...';
                 return;
             }
-            
-            const command = `python meshtastic_tiles.py --coords --north ${north} --south ${south} --east ${east} --west ${west} --min-zoom ${minZoom} --max-zoom ${maxZoom} --source ${source} --delay ${delay} --max-workers ${workers} --output-dir ${outputDir}`;
+
+            const parts = [
+                'python meshtastic_tiles.py --coords',
+                `--north ${north} --south ${south} --east ${east} --west ${west}`,
+                `--min-zoom ${minZoom} --max-zoom ${maxZoom}`,
+                `--source ${source}`,
+                `--delay ${delay} --max-workers ${workers}`,
+                `--output-dir ${outputDir}`,
+            ];
+            if (contact) parts.push(`--contact ${contact}`);
+            if (source !== 'osm-direct') {
+                parts.push(maptilerKey ? `--maptiler-key ${maptilerKey}` : '--maptiler-key "$MAPTILER_KEY"');
+            } else {
+                parts.push('--i-understand-osm-policy');
+            }
+            const command = parts.join(' ');
             
             document.getElementById('commandOutput').textContent = command;
         }
@@ -589,6 +619,9 @@ Select an area on the map to generate command...
         document.getElementById('delay').addEventListener('input', generateCommand);
         document.getElementById('workers').addEventListener('input', generateCommand);
         document.getElementById('outputDir').addEventListener('input', generateCommand);
+        document.getElementById('maptilerKey').addEventListener('input', generateCommand);
+        document.getElementById('contact').addEventListener('input', generateCommand);
+        document.getElementById('previewKey').addEventListener('change', changeMapStyle);
         
         // Manual coordinate input listeners
         ['north', 'south', 'east', 'west'].forEach(id => {

--- a/meshtastic_tiles.py
+++ b/meshtastic_tiles.py
@@ -316,7 +316,7 @@ class MeshtasticTileGenerator:
             "bounds": [west, south, east, north],
             "minzoom": min_zoom,
             "maxzoom": max_zoom,
-            "format": "png",
+            "format": "jpg" if source == 'satellite' else "png",
             "type": "baselayer",
             "source": source,
             "generated": time.strftime("%Y-%m-%d %H:%M:%S")

--- a/meshtastic_tiles.py
+++ b/meshtastic_tiles.py
@@ -15,8 +15,8 @@ from pathlib import Path
 import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-DEFAULT_CONTACT = 'ekarwatowski@gmail.com'
-REFERER = 'https://github.com/ekarwatowski/tdeck-maps'
+DEFAULT_CONTACT = os.environ.get('TDECK_MAPS_CONTACT')
+REFERER = os.environ.get('TDECK_MAPS_REFERER')
 OSM_POLICY_URL = 'https://operations.osmfoundation.org/policies/tiles/'
 
 

--- a/meshtastic_tiles.py
+++ b/meshtastic_tiles.py
@@ -15,11 +15,25 @@ from pathlib import Path
 import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+DEFAULT_CONTACT = 'ekarwatowski@gmail.com'
+REFERER = 'https://github.com/ekarwatowski/tdeck-maps'
+OSM_POLICY_URL = 'https://operations.osmfoundation.org/policies/tiles/'
+
+
+def build_user_agent(contact):
+    return f'tdeck-maps/1.0 ({contact})'
+
+
+class PolicyBlockedError(Exception):
+    """Raised when the remote tile server blocks us for policy violations."""
+
+
 class CityLookup:
-    def __init__(self):
+    def __init__(self, contact=DEFAULT_CONTACT):
         self.session = requests.Session()
         self.session.headers.update({
-            'User-Agent': 'MeshtasticTileGenerator/1.0'
+            'User-Agent': build_user_agent(contact),
+            'Referer': REFERER,
         })
     
     def get_coordinates(self, city, state=None, country=None):
@@ -111,13 +125,17 @@ class CityLookup:
         }
 
 class MeshtasticTileGenerator:
-    def __init__(self, output_dir="tiles", tile_size=256, delay=0.1):
+    def __init__(self, output_dir="tiles", tile_size=256, delay=0.5,
+                 contact=DEFAULT_CONTACT, maptiler_key=None):
         self.output_dir = Path(output_dir)
         self.tile_size = tile_size
         self.delay = delay  # Delay between requests to be respectful
+        self.maptiler_key = maptiler_key
         self.session = requests.Session()
         self.session.headers.update({
-            'User-Agent': 'MeshtasticTileGenerator/1.0'
+            'User-Agent': build_user_agent(contact),
+            'Referer': REFERER,
+            'Accept': 'image/png,image/jpeg,image/*;q=0.8',
         })
         
         # Create output directory
@@ -141,42 +159,73 @@ class MeshtasticTileGenerator:
     
     def get_tile_url(self, x, y, zoom, source="osm"):
         """Get tile URL for different map sources"""
+        key = self.maptiler_key or ''
         sources = {
-            "osm": f"https://tile.openstreetmap.org/{zoom}/{x}/{y}.png",
-            "satellite": f"https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{zoom}/{y}/{x}",
-            "terrain": f"https://tile.opentopomap.org/{zoom}/{x}/{y}.png",
-            "cycle": f"https://tile.thunderforest.com/cycle/{zoom}/{x}/{y}.png"
+            "osm":        f"https://api.maptiler.com/maps/openstreetmap/{zoom}/{x}/{y}.png?key={key}",
+            "satellite":  f"https://api.maptiler.com/tiles/satellite-v2/{zoom}/{x}/{y}.jpg?key={key}",
+            "terrain":    f"https://api.maptiler.com/maps/topo-v2/{zoom}/{x}/{y}.png?key={key}",
+            "osm-direct": f"https://tile.openstreetmap.org/{zoom}/{x}/{y}.png",
         }
         return sources.get(source, sources["osm"])
-    
+
+    def _tile_extension(self, source):
+        return 'jpg' if source == 'satellite' else 'png'
+
     def download_tile(self, x, y, zoom, source="osm"):
-        """Download a single tile"""
+        """Download a single tile with policy-compliant retries."""
         url = self.get_tile_url(x, y, zoom, source)
-        
-        # Create directory structure
+
         tile_dir = self.output_dir / str(zoom) / str(x)
         tile_dir.mkdir(parents=True, exist_ok=True)
-        
-        tile_path = tile_dir / f"{y}.png"
-        
-        # Skip if tile already exists
+        tile_path = tile_dir / f"{y}.{self._tile_extension(source)}"
+
         if tile_path.exists():
             return tile_path, True
-        
-        try:
-            response = self.session.get(url, timeout=10)
-            response.raise_for_status()
-            
-            # Save the tile
-            with open(tile_path, 'wb') as f:
-                f.write(response.content)
-            
-            time.sleep(self.delay)  # Be respectful to tile servers
-            return tile_path, True
-            
-        except Exception as e:
-            print(f"Error downloading tile {x},{y},{zoom}: {e}")
+
+        max_retries = 5
+        backoff = 1.0
+        for attempt in range(max_retries):
+            try:
+                response = self.session.get(url, timeout=15)
+            except requests.RequestException as e:
+                print(f"Network error {x},{y},{zoom} (attempt {attempt+1}): {e}")
+                time.sleep(min(backoff, 60))
+                backoff *= 2
+                continue
+
+            status = response.status_code
+            if status == 200:
+                ctype = response.headers.get('Content-Type', '')
+                if not ctype.startswith('image/'):
+                    print(f"Non-image response for {x},{y},{zoom} (Content-Type={ctype}); skipping")
+                    return None, False
+                with open(tile_path, 'wb') as f:
+                    f.write(response.content)
+                time.sleep(self.delay)
+                return tile_path, True
+
+            if status in (429, 403, 503):
+                retry_after = response.headers.get('Retry-After')
+                try:
+                    wait = float(retry_after) if retry_after else backoff
+                except ValueError:
+                    wait = backoff
+                wait = min(wait, 60)
+                print(f"HTTP {status} for {x},{y},{zoom}; backing off {wait:.1f}s (attempt {attempt+1}/{max_retries})")
+                if status == 403 and source == 'osm-direct':
+                    raise PolicyBlockedError(
+                        f"tile.openstreetmap.org returned 403 — bulk downloads are prohibited. "
+                        f"See {OSM_POLICY_URL}"
+                    )
+                time.sleep(wait)
+                backoff *= 2
+                continue
+
+            print(f"HTTP {status} for {x},{y},{zoom}; giving up")
             return None, False
+
+        print(f"Exceeded retries for {x},{y},{zoom}")
+        return None, False
     
     def generate_tiles(self, north, south, east, west, min_zoom=8, max_zoom=16, source="osm", max_workers=4):
         """Generate tiles for a bounding box"""
@@ -240,13 +289,19 @@ class MeshtasticTileGenerator:
                         futures.append(future)
             
             # Process completed downloads
-            for future in as_completed(futures):
-                tile_path, success = future.result()
-                if success:
-                    downloaded_tiles += 1
-                
-                if downloaded_tiles % 100 == 0:
-                    print(f"Downloaded {downloaded_tiles}/{total_tiles} tiles")
+            try:
+                for future in as_completed(futures):
+                    tile_path, success = future.result()
+                    if success:
+                        downloaded_tiles += 1
+
+                    if downloaded_tiles % 100 == 0:
+                        print(f"Downloaded {downloaded_tiles}/{total_tiles} tiles")
+            except PolicyBlockedError as e:
+                print(f"\n❌ Aborting: {e}")
+                for f in futures:
+                    f.cancel()
+                return
         
         print(f"Completed! Downloaded {downloaded_tiles}/{total_tiles} tiles")
         
@@ -372,19 +427,50 @@ def main():
     # Tile generation options
     parser.add_argument('--min-zoom', type=int, default=8, help='Minimum zoom level')
     parser.add_argument('--max-zoom', type=int, default=12, help='Maximum zoom level')
-    parser.add_argument('--source', default='osm', choices=['osm', 'satellite', 'terrain', 'cycle'],
-                        help='Map source')
+    parser.add_argument('--source', default='osm',
+                        choices=['osm', 'satellite', 'terrain', 'osm-direct'],
+                        help='Map source. "osm"/"satellite"/"terrain" use MapTiler (requires key). '
+                             '"osm-direct" hits tile.openstreetmap.org and is policy-restricted.')
+    parser.add_argument('--maptiler-key', default=os.environ.get('MAPTILER_KEY'),
+                        help='MapTiler API key (or set MAPTILER_KEY env var)')
+    parser.add_argument('--contact', default=DEFAULT_CONTACT,
+                        help='Contact email/URL embedded in User-Agent (tile provider policy)')
+    parser.add_argument('--i-understand-osm-policy', action='store_true',
+                        help='Required when using --source osm-direct. See ' + OSM_POLICY_URL)
     parser.add_argument('--output-dir', default='tiles', help='Output directory')
-    parser.add_argument('--delay', type=float, default=0.2, help='Delay between requests (seconds)')
-    parser.add_argument('--max-workers', type=int, default=3, help='Maximum concurrent downloads')
+    parser.add_argument('--delay', type=float, default=0.5, help='Delay between requests (seconds)')
+    parser.add_argument('--max-workers', type=int, default=2, help='Maximum concurrent downloads')
     parser.add_argument('--sample-only', action='store_true', help='Generate sample tile only')
     
     args = parser.parse_args()
-    
+
+    maptiler_sources = {'osm', 'satellite', 'terrain'}
+    if args.source in maptiler_sources and not args.maptiler_key:
+        print(f"Error: --source {args.source} uses MapTiler and requires an API key.")
+        print("Set MAPTILER_KEY env var or pass --maptiler-key. Get a free key at https://maptiler.com/")
+        return
+
+    if args.source == 'osm-direct':
+        print("⚠️  WARNING: --source osm-direct hits tile.openstreetmap.org directly.")
+        print(f"   OSM's tile policy prohibits bulk downloads: {OSM_POLICY_URL}")
+        print("   Expect 403 blocks. Consider --source osm (MapTiler) instead.")
+        if not args.i_understand_osm_policy:
+            print("   Re-run with --i-understand-osm-policy to proceed anyway.")
+            return
+        # Enforce OSM policy caps regardless of user flags.
+        if args.max_workers > 2:
+            print("   Capping --max-workers at 2 for osm-direct.")
+            args.max_workers = 2
+        if args.delay < 1.0:
+            print("   Raising --delay to 1.0 for osm-direct.")
+            args.delay = 1.0
+
     # Create generator
     generator = MeshtasticTileGenerator(
         output_dir=args.output_dir,
-        delay=args.delay
+        delay=args.delay,
+        contact=args.contact,
+        maptiler_key=args.maptiler_key,
     )
     
     if args.sample_only:
@@ -406,7 +492,7 @@ def main():
         
     elif args.city:
         # Single city lookup
-        lookup = CityLookup()
+        lookup = CityLookup(contact=args.contact)
         coord = lookup.get_coordinates(args.city)
         if not coord:
             print(f"Could not find coordinates for: {args.city}")
@@ -424,7 +510,7 @@ def main():
         
     elif args.cities:
         # Multiple cities lookup
-        lookup = CityLookup()
+        lookup = CityLookup(contact=args.contact)
         cities = [city.strip() for city in args.cities.split(';')]
         bbox = lookup.get_bounding_box_for_cities(cities, args.buffer)
         if not bbox:


### PR DESCRIPTION
## Summary

Downloaded tiles from `tile.openstreetmap.org` are returning **403 Access Blocked** because the tool violates OSM's [Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/) — specifically the prohibition on bulk downloading. This PR fixes the root cause rather than trying to mask it.

**Core change:** default `osm`/`satellite`/`terrain` sources now route through **MapTiler** (free tier, explicitly permits offline caching with an API key). Raw OSM remains available as an opt-in `osm-direct` source gated behind `--i-understand-osm-policy` with hard-capped concurrency (workers=2, delay≥1s).

**Policy-compliant HTTP client:**
- Real `User-Agent: tdeck-maps/1.0 (<contact>)` with contact info, plus `Referer` — required by MapTiler, OSM, and Nominatim policies
- Exponential backoff on 429/403/503, honors `Retry-After`
- Rejects non-image responses instead of silently saving error HTML as `.png`
- Aborts the whole run on persistent 403 from `osm-direct` with a pointer to the policy URL
- Defaults lowered: `--max-workers 3 → 2`, `--delay 0.2 → 0.5`

**GUI (`maps.html`):** adds a MapTiler key field + contact field, emits `--maptiler-key`/`--contact`/`--i-understand-osm-policy` in the generated command, and switches the Leaflet preview layer to MapTiler so panning the preview no longer hammers OSM's servers either.

**Docs:** README now explains the MapTiler key requirement up-front and why OSM direct is restricted.

## Commits (bisectable)

1. `chore: ignore tiles output and .DS_Store`
2. `fix: route tile downloads through MapTiler; restrict direct OSM` — core client + CLI
3. `feat(gui): add MapTiler key + contact fields; switch preview to MapTiler`
4. `docs: document MapTiler key requirement and OSM policy rationale`

## Test plan

- [x] Syntax check: `python3 -c "import ast; ast.parse(open('meshtastic_tiles.py').read())"` passes
- [x] `--help` renders new flags (`--maptiler-key`, `--contact`, `--i-understand-osm-policy`, new `--source` choices)
- [x] Missing-key guard: `python3 meshtastic_tiles.py --city "Portland" --source osm` exits cleanly with "MapTiler key required" message
- [x] `osm-direct` gate: refuses to run without `--i-understand-osm-policy` and prints the policy URL
- [ ] End-to-end: `MAPTILER_KEY=<key> python3 meshtastic_tiles.py --city "Portland" --min-zoom 10 --max-zoom 11` — download completes, tiles are valid PNGs (needs reviewer's MapTiler key)
- [ ] GUI smoke: open `maps.html`, enter MapTiler key, verify preview loads from `api.maptiler.com` (check Network tab) and generated command includes `--maptiler-key`

## Notes

- MapTiler's free tier (100k tile requests/month) is generous enough for the T-Deck offline use case. Get a key at https://maptiler.com/.
- The default `--contact` is hardcoded to the author's email (`ekarwatowski@gmail.com`); redistributors should override with their own via `--contact` or the GUI contact field.
- `--source cycle` (Thunderforest, required a key that was never wired up) has been removed since it was already broken.